### PR TITLE
fix: updated Marvel API url from http to https

### DIFF
--- a/backend/services/marvelAPIService.js
+++ b/backend/services/marvelAPIService.js
@@ -16,7 +16,7 @@ export const getCharacter = async (character) => {
     try {
         const ts = Date.now().toString();
         const hash = generateHash(ts, privateKey, publicKey);
-        const url = `http://gateway.marvel.com/v1/public/characters?ts=${ts}&apikey=${publicKey}&hash=${hash}&name=${character}`;
+        const url = `https://gateway.marvel.com/v1/public/characters?ts=${ts}&apikey=${publicKey}&hash=${hash}&name=${character}`;
         const response = await axios.get(url, { timeout: 10000 });
 
         return response.data.data.results;
@@ -30,7 +30,7 @@ export const getRecommendatons = async (string) => {
     try {
         const ts = Date.now().toString();
         const hash = generateHash(ts, privateKey, publicKey);
-        const url = `http://gateway.marvel.com/v1/public/characters?ts=${ts}&apikey=${publicKey}&hash=${hash}&nameStartsWith=${string}`;
+        const url = `https://gateway.marvel.com/v1/public/characters?ts=${ts}&apikey=${publicKey}&hash=${hash}&nameStartsWith=${string}`;
         const response = await axios.get(url, { timeout: 10000 });
 
         const results = response.data.data.results;


### PR DESCRIPTION
Originally, HTTP requests were working, but it appears the Marvel API has since been updated to require HTTPS. This change likely caused the HTTP requests to fail, so I've updated the endpoint to use HTTPS accordingly.