### PR TITLE
fix: Express server to serve Vite production build output folder

### DIFF
--- a/frontend/src/js/characters.js
+++ b/frontend/src/js/characters.js
@@ -5,7 +5,7 @@ import {
     updateRecommendations
 } from './shared.js';
 
-import { getApiUrl } from '@utils/getAPIUrl.js';
+import { getApiUrl } from '../utils/getAPIUrl.js';
 const searchForm = document.getElementById('search-form');
 
 searchForm.addEventListener('submit', async (event) => {

--- a/frontend/src/js/snap.js
+++ b/frontend/src/js/snap.js
@@ -6,8 +6,8 @@ import {
     clearCards
 } from './shared.js';
 
-import { createFilterObject } from '@utils/queryUtil.js';
-import { getApiUrl } from '@utils/getAPIUrl.js';
+import { createFilterObject } from '../utils/queryUtil.js';
+import { getApiUrl } from '../utils/getAPIUrl.js';
 
 const searchForm = document.getElementById('search-data');
 const allFilters = document.querySelectorAll('[name^="filter"]');

--- a/frontend/src/views/characters.html
+++ b/frontend/src/views/characters.html
@@ -5,9 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="stylesheet" href="/css/main.css" />
         <link rel="stylesheet" href="/css/characters.css" />
-        <script type="module">
-            import '@js/characters.js';
-        </script>
+        <script type="module" src="../js/characters.js"></script>
         <title>Marvel Characters</title>
     </head>
     <body>

--- a/frontend/src/views/marvelSnap.html
+++ b/frontend/src/views/marvelSnap.html
@@ -5,9 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="stylesheet" href="/css/main.css" />
         <link rel="stylesheet" href="/css/snap.css" />
-        <script type="module">
-            import '@js/snap.js';
-        </script>
+        <script type="module" src="../js/snap.js"></script>
         <title>Marvel Snap</title>
     </head>
     <body>

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(express.json());
-app.use(express.static(path.join(__dirname, '/frontend/public')));
+app.use(express.static(path.join(__dirname, '/frontend/dist')));
 
 app.use('/api/characters', characterRouter);
 app.use('/database', snapRouter);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,4 @@
 import { defineConfig } from 'vite';
-import path from 'path';
 
 export default defineConfig({
     root: 'frontend/src/views',
@@ -12,12 +11,6 @@ export default defineConfig({
                 characters: 'frontend/src/views/characters.html',
                 marvelSnap: 'frontend/src/views/marvelSnap.html'
             }
-        }
-    },
-    resolve: {
-        alias: {
-            '@js': path.resolve(__dirname, 'frontend/src/js'),
-            '@utils': path.resolve(__dirname, 'frontend/src/utils')
         }
     },
     publicDir: '../../../frontend/public',


### PR DESCRIPTION
Fixed Express static serving to use the /dist folder and updated frontend
code to move inline ES6 imports into external JS files for proper bundling.